### PR TITLE
Add shell history to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Thumbs.db
 *.temp
 *.bak
 *.orig
+
+# Shell history
+history.txt


### PR DESCRIPTION
## Summary
Add shell history files to gitignore to keep repository clean.

## Changes Made
- Add `history.txt` to `.gitignore` under "Shell history" section
- Prevents accidental commit of temporary shell command history files

## Files Modified
- `.gitignore` - Added shell history exclusion pattern

## Benefits
- **Repository cleanliness**: Prevents temporary files from being tracked
- **Developer experience**: No need to manually exclude history files
- **Consistency**: Follows standard practices for ignoring temporary files

## Test plan
- [x] gitignore pattern properly excludes history.txt files
- [x] No impact on existing tracked files