### PR TITLE
fix: Windows compatibility and REST API migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "json"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 thiserror = "2.0"
 ctrlc = "3.4"
-daemonize = "0.5"
 reqwest = { version = "0.12", features = ["json"] }
 rustyline = { version = "14.0", features = ["derive"] }
 dirs = "5.0"
@@ -30,3 +29,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 utoipa = { version = "5.4", features = ["axum_extras", "uuid"] }
 utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
+
+[target.'cfg(unix)'.dependencies]
+daemonize = "0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod rbac;
 mod rest;
 
 use anyhow::Result;
+#[cfg(unix)]
 use daemonize::Daemonize;
 use rustyline::completion::{Completer, Pair};
 use rustyline::highlight::Highlighter;
@@ -74,8 +75,16 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     // Handle daemon mode first (no tokio runtime needed)
+    #[cfg(unix)]
     if args.len() >= 2 && args[1] == "serve" {
         return start_server_daemon();
+    }
+    
+    #[cfg(not(unix))]
+    if args.len() >= 2 && args[1] == "serve" {
+        eprintln!("Error: 'serve' command is not supported on Windows.");
+        eprintln!("Please use 'raworc start' to run the server in foreground mode.");
+        return Err(anyhow::anyhow!("Unsupported command on Windows"));
     }
 
     // For all other commands, use tokio runtime
@@ -167,6 +176,7 @@ async fn start_server() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn start_server_daemon() -> Result<()> {
     use std::fs;
     use std::path::Path;
@@ -247,37 +257,62 @@ fn start_server_daemon() -> Result<()> {
 
 async fn stop_server() -> Result<()> {
     use std::fs;
-    use std::process;
 
+    #[cfg(unix)]
     let pid_file = "/tmp/raworc.pid";
+    #[cfg(windows)]
+    let pid_file = std::env::temp_dir().join("raworc.pid");
 
-    match fs::read_to_string(pid_file) {
+    match fs::read_to_string(&pid_file) {
         Ok(pid_str) => {
             match pid_str.trim().parse::<u32>() {
                 Ok(pid) => {
                     println!("Stopping Raworc server (PID: {pid})...");
 
                     // Try to kill the process
-                    match process::Command::new("kill").arg(pid.to_string()).output() {
-                        Ok(output) => {
-                            if output.status.success() {
-                                println!("Server stopped successfully.");
-                                // Remove PID file
-                                let _ = fs::remove_file(pid_file);
-                            } else {
-                                eprintln!(
-                                    "Failed to stop server: {stderr}",
-                                    stderr = String::from_utf8_lossy(&output.stderr)
-                                );
+                    #[cfg(unix)]
+                    {
+                        use std::process::Command;
+                        match Command::new("kill").arg(pid.to_string()).output() {
+                            Ok(output) => {
+                                if output.status.success() {
+                                    println!("Server stopped successfully.");
+                                    // Remove PID file
+                                    let _ = fs::remove_file(pid_file);
+                                } else {
+                                    eprintln!("Failed to stop server: {}", String::from_utf8_lossy(&output.stderr));
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("Failed to execute kill command: {e}");
                             }
                         }
-                        Err(e) => {
-                            eprintln!("Failed to execute kill command: {e}");
+                    }
+                    
+                    #[cfg(windows)]
+                    {
+                        use std::process::Command;
+                        match Command::new("taskkill").args(&["/F", "/PID", &pid.to_string()]).output() {
+                            Ok(output) => {
+                                if output.status.success() {
+                                    println!("Server stopped successfully.");
+                                    // Remove PID file
+                                    let _ = fs::remove_file(pid_file);
+                                } else {
+                                    eprintln!("Failed to stop server: {}", String::from_utf8_lossy(&output.stderr));
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("Failed to execute taskkill command: {e}");
+                            }
                         }
                     }
                 }
                 Err(_) => {
-                    eprintln!("Invalid PID in {pid_file}");
+                    #[cfg(unix)]
+                    eprintln!("Invalid PID in {}", pid_file);
+                    #[cfg(windows)]
+                    eprintln!("Invalid PID in {}", pid_file.display());
                     let _ = fs::remove_file(pid_file);
                 }
             }
@@ -752,6 +787,7 @@ fn print_help() {
     println!("COMMANDS:");
     println!("    (default)          Connect to authenticated server");
     println!("    start              Start the Raworc server in foreground");
+    #[cfg(unix)]
     println!("    serve              Start the Raworc server as daemon");
     println!("    stop               Stop the running Raworc server");
     println!("    connect            Connect to authenticated server");


### PR DESCRIPTION
## Summary
This PR includes two major improvements:
1. Complete migration from GraphQL to REST API
2. Windows compatibility fix for the daemon mode

## Changes

### REST API Migration
- Replace GraphQL with REST API using Axum framework
- Add OpenAPI/Swagger documentation with interactive UI at `/swagger-ui`
- Implement request logging middleware for all API calls
- Enhance CLI with full REST operation support (GET/POST/PUT/DELETE)
- Remove all GraphQL dependencies and artifacts
- Create comprehensive documentation structure in `/docs` folder

### Windows Compatibility
- Make `daemonize` a Unix-only dependency
- Disable `serve` command on Windows with helpful error message
- Update help text to only show daemon mode on Unix systems
- All other functionality works identically across platforms

## Breaking Changes
⚠️ **All API endpoints have changed from GraphQL to REST**
- GraphQL endpoint `/graphql` is removed
- New REST endpoints under `/api/v1/*`
- Authentication endpoint changed to `/api/v1/auth/login`

## Migration Guide
Clients need to update from GraphQL queries to REST endpoints:
- `query { serviceAccounts }` → `GET /api/v1/service-accounts`
- `mutation createRole` → `POST /api/v1/roles`
- See full API documentation at `/swagger-ui` when server is running

## Windows Users
- Use `raworc start` to run the server in foreground mode
- The `serve` command is not available on Windows (Unix-only)
- All other commands work identically to Unix/Linux

## Testing
- ✅ All REST endpoints tested and working
- ✅ Windows build tested - daemon mode properly disabled
- ✅ CLI enhanced with full REST support
- ✅ Authentication and RBAC system intact

## Documentation
- REST API reference: `/docs/rest-api.md`
- Quick start guide: `/docs/quickstart.md`
- CLI examples: `/docs/cli-api-examples.md`
- Live Swagger UI: `http://localhost:9000/swagger-ui/`