### PR TITLE
fix: disable serve command on Windows for cross-platform compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "json"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 thiserror = "2.0"
 ctrlc = "3.4"
-daemonize = "0.5"
+# daemonize = "0.5"  # Moved to Unix-only dependencies
 reqwest = { version = "0.12", features = ["json"] }
 rustyline = { version = "14.0", features = ["derive"] }
 dirs = "5.0"
@@ -30,3 +30,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 utoipa = { version = "5.4", features = ["axum_extras", "uuid"] }
 utoipa-swagger-ui = { version = "9.0", features = ["axum"] }
+
+[target.'cfg(unix)'.dependencies]
+daemonize = "0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod rbac;
 mod rest;
 
 use anyhow::Result;
+#[cfg(unix)]
 use daemonize::Daemonize;
 use rustyline::completion::{Completer, Pair};
 use rustyline::highlight::Highlighter;
@@ -74,8 +75,16 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     // Handle daemon mode first (no tokio runtime needed)
+    #[cfg(unix)]
     if args.len() >= 2 && args[1] == "serve" {
         return start_server_daemon();
+    }
+    
+    #[cfg(not(unix))]
+    if args.len() >= 2 && args[1] == "serve" {
+        eprintln!("Error: 'serve' command is not supported on Windows.");
+        eprintln!("Please use 'raworc start' to run the server in foreground mode.");
+        return Err(anyhow::anyhow!("Unsupported command on Windows"));
     }
 
     // For all other commands, use tokio runtime
@@ -167,6 +176,7 @@ async fn start_server() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn start_server_daemon() -> Result<()> {
     use std::fs;
     use std::path::Path;
@@ -752,6 +762,7 @@ fn print_help() {
     println!("COMMANDS:");
     println!("    (default)          Connect to authenticated server");
     println!("    start              Start the Raworc server in foreground");
+    #[cfg(unix)]
     println!("    serve              Start the Raworc server as daemon");
     println!("    stop               Stop the running Raworc server");
     println!("    connect            Connect to authenticated server");


### PR DESCRIPTION
## Summary
- Disabled the `serve` command on Windows since daemonize doesn't support Windows
- Made daemonize a Unix-only dependency 
- Added clear error message when Windows users try to use `serve`

## Changes
- Moved daemonize to Unix-only dependencies in Cargo.toml
- Added conditional compilation (#[cfg(unix)]) around daemon-related code
- Updated help text to only show `serve` command on Unix systems
- Added helpful error message directing Windows users to use `raworc start` instead

## Test plan
- [x] Builds successfully on Unix systems with daemonize support
- [ ] Windows users see clear error when attempting to use `serve` command
- [ ] `raworc start` works on all platforms for foreground mode
- [ ] Help text correctly shows/hides `serve` based on platform