### PR TITLE
fix: remove broken architecture diagram link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Rather than running persistent agents, Raworc organizes work into discrete, mana
 
 ## Architecture
 
-<div align="center">
-  <img src="assets/raworc-architecture.excalidraw.png" alt="Raworc Architecture" width="800"/>
-</div>
-
 ### Core Components
 
 **Control Plane:**


### PR DESCRIPTION
## Summary
Remove non-existent architecture diagram reference from README

## Changes
- Removed broken image link to `assets/raworc-architecture.excalidraw.png`
- The file doesn't exist in the repository

## Test plan
- [x] Verified image file is not in assets/ directory
- [x] README renders without broken images