### PR TITLE
fix: make Swagger UI work with any domain instead of hardcoded localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Rather than running persistent agents, Raworc organizes work into discrete, mana
 - [RBAC Guide](docs/rbac.md) - Role-based access control
 
 ### Live Documentation (requires running server)
-- [Swagger UI](http://localhost:9000/swagger-ui/) - Interactive API explorer
-- [OpenAPI Spec](http://localhost:9000/api-docs/openapi.json) - OpenAPI 3.0 specification
+- **Swagger UI** - Interactive API explorer at `/swagger-ui/`
+- **OpenAPI Spec** - OpenAPI 3.0 specification at `/api-docs/openapi.json`
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,8 +41,8 @@ psql $DATABASE_URL < migrations/001_create_rbac_tables.sql
 - **[RBAC System](rbac.md)** - Role-based access control explained
 
 ### Interactive Documentation (requires running server)
-- **[Swagger UI](http://localhost:9000/swagger-ui/)** - Interactive API explorer
-- **[OpenAPI Spec](http://localhost:9000/api-docs/openapi.json)** - OpenAPI 3.0 specification
+- **Swagger UI** - Available at `/swagger-ui/` on your server
+- **OpenAPI Spec** - Available at `/api-docs/openapi.json` on your server
 
 ## 🔧 Quick Reference
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -4,15 +4,15 @@
 
 Raworc provides a comprehensive REST API for managing platform operations, authentication, and role-based access control.
 
-- **Base URL**: `http://localhost:9000/api/v1`
+- **Base URL**: `/api/v1`
 - **Authentication**: Bearer token (JWT)
 - **Content-Type**: `application/json`
 
 ## OpenAPI Documentation
 
 When the server is running, you can access:
-- **Swagger UI**: http://localhost:9000/swagger-ui/
-- **OpenAPI JSON**: http://localhost:9000/api-docs/openapi.json
+- **Swagger UI**: `/swagger-ui/`
+- **OpenAPI JSON**: `/api-docs/openapi.json`
 
 ## Authentication
 

--- a/src/rest/openapi.rs
+++ b/src/rest/openapi.rs
@@ -70,7 +70,7 @@ use crate::rbac::SubjectType;
         license(name = "MIT"),
     ),
     servers(
-        (url = "http://localhost:9000", description = "Local development server"),
+        (url = "/", description = "Current server"),
     ),
 )]
 pub struct ApiDoc;


### PR DESCRIPTION
## Summary
Fix Swagger UI to work correctly when hosted on different domains by removing hardcoded localhost references.

## Problem
- Swagger UI was configured with hardcoded `http://localhost:9000` as the server URL
- This caused API calls from Swagger UI to fail when the application was hosted on a different domain
- Documentation also had hardcoded localhost URLs

## Solution
- Changed OpenAPI server configuration from `http://localhost:9000` to relative path `/`
- Updated all documentation to use relative paths instead of absolute URLs
- Swagger UI now automatically uses the current domain for API calls

## Changes
1. **OpenAPI Configuration** (`src/rest/openapi.rs`):
   - Changed server URL from `http://localhost:9000` to `/`
   
2. **Documentation Updates**:
   - `README.md`: Changed localhost URLs to relative paths
   - `docs/index.md`: Updated to mention paths instead of full URLs  
   - `docs/rest-api.md`: Changed base URL and OpenAPI links to relative

## Benefits
- Swagger UI works correctly on any domain (production, staging, local development)
- No need to rebuild or reconfigure for different deployments
- API calls from Swagger UI automatically use the correct host

## Test plan
- [x] Swagger UI loads correctly
- [ ] API calls from Swagger UI use the current domain
- [ ] Works when accessed via different domains/ports
- [ ] Documentation reflects relative paths