### PR TITLE
feat: rename external-login endpoint to external

### DIFF
--- a/src/rest/openapi.rs
+++ b/src/rest/openapi.rs
@@ -127,7 +127,7 @@ pub async fn login() {}
 
 #[utoipa::path(
     post,
-    path = "/api/v1/auth/external-login",
+    path = "/api/v1/auth/external",
     tag = "Auth",
     request_body = ExternalLoginRequest,
     security(

--- a/src/rest/routes.rs
+++ b/src/rest/routes.rs
@@ -18,7 +18,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/health", get(health))
         .route("/version", get(version))
         .route("/auth/login", post(auth::login))
-        .route("/auth/external-login", post(auth::external_login));
+        .route("/auth/external", post(auth::external_login));
     
     // Protected routes
     let protected_routes = Router::new()


### PR DESCRIPTION
## Summary
- Renamed `/auth/external-login` endpoint to `/auth/external` for brevity
- Updated OpenAPI path documentation accordingly

## Changes
- `src/rest/routes.rs`: Updated route path
- `src/rest/openapi.rs`: Updated OpenAPI path annotation

The functionality remains the same - admins can create JWT tokens for external subjects without passwords.