### PR TITLE
feat: rename auth/login endpoint to auth/internal

### DIFF
--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -130,7 +130,7 @@ Tokens include the following claims:
 ## API Endpoints
 
 See the [REST API Documentation](rest-api.md) for detailed information on RBAC-related endpoints:
-- `/auth/login` - Authenticate and get token
+- `/auth/internal` - Authenticate and get token
 - `/service-accounts` - Manage service accounts
 - `/roles` - Manage roles
 - `/role-bindings` - Manage role bindings

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -16,7 +16,7 @@ When the server is running, you can access:
 
 ## Authentication
 
-All endpoints except `/health`, `/version`, and `/auth/login` require authentication via Bearer token.
+All endpoints except `/health`, `/version`, and `/auth/internal` require authentication via Bearer token.
 
 Include the token in the Authorization header:
 ```
@@ -45,7 +45,7 @@ Get API version information.
 
 ### Authentication
 
-#### POST /auth/login
+#### POST /auth/internal
 Authenticate a service account and receive a JWT token.
 
 **Request**:

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,7 +420,7 @@ async fn auth_login() -> Result<()> {
     });
 
     let response = client
-        .post(format!("{server_url}/api/v1/auth/login"))
+        .post(format!("{server_url}/api/v1/auth/internal"))
         .header("Content-Type", "application/json")
         .json(&login_request)
         .send()

--- a/src/rest/openapi.rs
+++ b/src/rest/openapi.rs
@@ -114,7 +114,7 @@ pub async fn version() {}
 // Auth endpoints
 #[utoipa::path(
     post,
-    path = "/api/v1/auth/login",
+    path = "/api/v1/auth/internal",
     tag = "Auth",
     request_body = LoginRequest,
     responses(

--- a/src/rest/routes.rs
+++ b/src/rest/routes.rs
@@ -17,7 +17,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let public_routes = Router::new()
         .route("/health", get(health))
         .route("/version", get(version))
-        .route("/auth/login", post(auth::login))
+        .route("/auth/internal", post(auth::login))
         .route("/auth/external", post(auth::external_login));
     
     // Protected routes


### PR DESCRIPTION
## Summary
- Renamed `/auth/login` endpoint to `/auth/internal` for consistency with `/auth/external`
- Updated all references across the codebase

## Changes
- `src/rest/routes.rs`: Updated route path
- `src/rest/openapi.rs`: Updated OpenAPI path annotation
- `src/main.rs`: Updated CLI authentication request
- `docs/rest-api.md`: Updated API documentation
- `docs/rbac.md`: Updated RBAC documentation

This change creates a clear naming pattern:
- `/auth/internal` - For service account authentication (requires password)
- `/auth/external` - For external subject authentication (admin-only, no password)