### PR TITLE
feat: implement agent CRUD functionality

### DIFF
--- a/docs/agent-testing-plan.md
+++ b/docs/agent-testing-plan.md
@@ -1,0 +1,100 @@
+# Agent Management Testing Plan
+
+## Prerequisites
+1. PostgreSQL database running
+2. DATABASE_URL environment variable set
+3. Run migrations:
+   ```bash
+   psql $DATABASE_URL < migrations/001_create_rbac_tables.sql
+   psql $DATABASE_URL < migrations/002_create_agents_table.sql
+   ```
+
+## Test Cases
+
+### 1. List Agents
+```bash
+# Start server
+raworc start
+
+# In another terminal, authenticate
+raworc auth
+
+# List agents (should show default "assistant" agent)
+raworc connect
+raworc> /api agents
+```
+
+### 2. Create Agent
+```bash
+# Create a new agent
+raworc> /api POST agents {"name":"code-helper","instructions":"Help with coding tasks","model":"gpt-4","description":"Coding assistant"}
+
+# Verify creation
+raworc> /api agents/code-helper
+```
+
+### 3. Update Agent
+```bash
+# Update agent instructions
+raworc> /api PUT agents/code-helper {"instructions":"Expert coding assistant focused on best practices"}
+
+# Update multiple fields
+raworc> /api PUT agents/code-helper {"model":"gpt-4-turbo","tools":["linter","formatter"],"active":true}
+```
+
+### 4. Agent with Complex Fields
+```bash
+# Create agent with all fields
+raworc> /api POST agents {
+  "name": "security-reviewer",
+  "description": "Security-focused code reviewer",
+  "instructions": "Review code for security vulnerabilities",
+  "model": "gpt-4",
+  "tools": ["semgrep", "bandit", "safety"],
+  "routes": [
+    {"pattern": "*.py", "priority": 1},
+    {"pattern": "*.js", "priority": 2}
+  ],
+  "guardrails": ["no-eval", "no-exec", "input-validation"],
+  "knowledge_bases": ["owasp-top-10", "cwe-database"]
+}
+```
+
+### 5. Delete Agent
+```bash
+# Soft delete an agent
+raworc> /api DELETE agents/code-helper
+
+# Verify it's no longer in active list
+raworc> /api agents
+
+# Try to get deleted agent (should return 404)
+raworc> /api agents/code-helper
+```
+
+### 6. Error Cases
+```bash
+# Duplicate name
+raworc> /api POST agents {"name":"assistant","instructions":"test","model":"gpt-4"}
+# Expected: 409 Conflict
+
+# Invalid ID format
+raworc> /api PUT agents/invalid-uuid {"model":"gpt-4"}
+# Expected: 400 Bad Request
+
+# Non-existent agent
+raworc> /api agents/non-existent
+# Expected: 404 Not Found
+```
+
+## Swagger UI Testing
+1. Navigate to http://localhost:9000/swagger-ui/
+2. Use the "Authorize" button to add Bearer token
+3. Test all agent endpoints through the UI
+
+## Expected Behaviors
+- Agents are soft-deleted (active=false) rather than removed
+- Agent names must be unique
+- JSON fields (tools, routes, guardrails, knowledge_bases) default to empty arrays
+- Timestamps are automatically managed
+- Can lookup agents by either UUID or name

--- a/docs/cli-api-examples.md
+++ b/docs/cli-api-examples.md
@@ -53,6 +53,24 @@ raworc> /api DELETE service-accounts/bot-user
 raworc> /api DELETE role-bindings/some-binding-id
 ```
 
+### Agent Management
+```bash
+# List all agents
+raworc> /api agents
+
+# Get specific agent by name or ID
+raworc> /api agents/assistant
+
+# Create a new agent
+raworc> /api POST agents {"name":"code-assistant","instructions":"You are a helpful coding assistant","model":"gpt-4","description":"Helps with code reviews and debugging"}
+
+# Update an agent
+raworc> /api PUT agents/code-assistant {"instructions":"You are an expert code reviewer focused on security","model":"gpt-4-turbo"}
+
+# Delete an agent
+raworc> /api DELETE agents/code-assistant
+```
+
 ## Response Format
 
 All commands show:

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -228,6 +228,90 @@ Delete a role binding by ID.
 
 **Response**: `200 OK`
 
+### Agents
+
+#### GET /agents
+List all active agents.
+
+**Response**:
+```json
+[
+  {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "assistant",
+    "description": "General purpose assistant agent",
+    "instructions": "You are a helpful AI assistant. Be concise and accurate in your responses.",
+    "model": "gpt-4",
+    "tools": [],
+    "routes": [],
+    "guardrails": [],
+    "knowledge_bases": [],
+    "active": true,
+    "created_at": "2025-01-01T00:00:00Z",
+    "updated_at": "2025-01-01T00:00:00Z"
+  }
+]
+```
+
+#### POST /agents
+Create a new agent.
+
+**Request**:
+```json
+{
+  "name": "code-reviewer",
+  "description": "Code review specialist",
+  "instructions": "You are an expert code reviewer. Focus on security, performance, and best practices.",
+  "model": "gpt-4-turbo",
+  "tools": ["static-analysis", "security-scan"],
+  "routes": [{"pattern": "*.py", "weight": 1.0}],
+  "guardrails": ["no-secrets", "no-pii"],
+  "knowledge_bases": ["python-best-practices"]
+}
+```
+
+**Response**: Same as GET /agents/{id}
+
+#### GET /agents/{id}
+Get a specific agent by ID or name.
+
+**Response**:
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "assistant",
+  "description": "General purpose assistant agent",
+  "instructions": "You are a helpful AI assistant. Be concise and accurate in your responses.",
+  "model": "gpt-4",
+  "tools": [],
+  "routes": [],
+  "guardrails": [],
+  "knowledge_bases": [],
+  "active": true,
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
+}
+```
+
+#### PUT /agents/{id}
+Update an agent by ID.
+
+**Request**:
+```json
+{
+  "instructions": "Updated instructions for the agent",
+  "model": "gpt-4-turbo",
+  "active": true
+}
+```
+
+**Response**: Same as GET /agents/{id}
+
+#### DELETE /agents/{id}
+Delete (soft delete) an agent by ID.
+
+**Response**: `204 No Content`
+
 ## Error Responses
 
 All errors follow a consistent format:

--- a/migrations/002_create_agents_table.sql
+++ b/migrations/002_create_agents_table.sql
@@ -1,0 +1,37 @@
+-- Create agents table
+CREATE TABLE IF NOT EXISTS agents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    instructions TEXT NOT NULL,
+    model VARCHAR(255) NOT NULL,
+    tools JSONB DEFAULT '[]'::jsonb,
+    routes JSONB DEFAULT '[]'::jsonb,
+    guardrails JSONB DEFAULT '[]'::jsonb,
+    knowledge_bases JSONB DEFAULT '[]'::jsonb,
+    active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create index on name for fast lookups
+CREATE INDEX idx_agents_name ON agents(name);
+
+-- Create index on active for filtering
+CREATE INDEX idx_agents_active ON agents(active);
+
+-- Create updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_agents_updated_at BEFORE UPDATE
+    ON agents FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+-- Insert a default agent for testing
+INSERT INTO agents (name, description, instructions, model) VALUES
+    ('assistant', 'General purpose assistant agent', 'You are a helpful AI assistant. Be concise and accurate in your responses.', 'gpt-4');

--- a/src/models/agent.rs
+++ b/src/models/agent.rs
@@ -1,0 +1,175 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct Agent {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub instructions: String,
+    pub model: String,
+    pub tools: serde_json::Value,
+    pub routes: serde_json::Value,
+    pub guardrails: serde_json::Value,
+    pub knowledge_bases: serde_json::Value,
+    pub active: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CreateAgentRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub instructions: String,
+    pub model: String,
+    #[serde(default = "default_json_array")]
+    pub tools: serde_json::Value,
+    #[serde(default = "default_json_array")]
+    pub routes: serde_json::Value,
+    #[serde(default = "default_json_array")]
+    pub guardrails: serde_json::Value,
+    #[serde(default = "default_json_array")]
+    pub knowledge_bases: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct UpdateAgentRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub instructions: Option<String>,
+    pub model: Option<String>,
+    pub tools: Option<serde_json::Value>,
+    pub routes: Option<serde_json::Value>,
+    pub guardrails: Option<serde_json::Value>,
+    pub knowledge_bases: Option<serde_json::Value>,
+    pub active: Option<bool>,
+}
+
+fn default_json_array() -> serde_json::Value {
+    serde_json::json!([])
+}
+
+// Database queries
+impl Agent {
+    pub async fn find_all(pool: &sqlx::PgPool) -> Result<Vec<Agent>, sqlx::Error> {
+        sqlx::query_as::<_, Agent>(
+            r#"
+            SELECT id, name, description, instructions, model, 
+                   tools, routes, guardrails, knowledge_bases,
+                   active, created_at, updated_at
+            FROM agents
+            WHERE active = true
+            ORDER BY name ASC
+            "#
+        )
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn find_by_id(pool: &sqlx::PgPool, id: Uuid) -> Result<Option<Agent>, sqlx::Error> {
+        sqlx::query_as::<_, Agent>(
+            r#"
+            SELECT id, name, description, instructions, model,
+                   tools, routes, guardrails, knowledge_bases,
+                   active, created_at, updated_at
+            FROM agents
+            WHERE id = $1
+            "#
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn find_by_name(pool: &sqlx::PgPool, name: &str) -> Result<Option<Agent>, sqlx::Error> {
+        sqlx::query_as::<_, Agent>(
+            r#"
+            SELECT id, name, description, instructions, model,
+                   tools, routes, guardrails, knowledge_bases,
+                   active, created_at, updated_at
+            FROM agents
+            WHERE name = $1
+            "#
+        )
+        .bind(name)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn create(pool: &sqlx::PgPool, req: CreateAgentRequest) -> Result<Agent, sqlx::Error> {
+        sqlx::query_as::<_, Agent>(
+            r#"
+            INSERT INTO agents (name, description, instructions, model, tools, routes, guardrails, knowledge_bases)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING id, name, description, instructions, model,
+                      tools, routes, guardrails, knowledge_bases,
+                      active, created_at, updated_at
+            "#
+        )
+        .bind(req.name)
+        .bind(req.description)
+        .bind(req.instructions)
+        .bind(req.model)
+        .bind(req.tools)
+        .bind(req.routes)
+        .bind(req.guardrails)
+        .bind(req.knowledge_bases)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn update(pool: &sqlx::PgPool, id: Uuid, req: UpdateAgentRequest) -> Result<Option<Agent>, sqlx::Error> {
+        // Build dynamic update query based on provided fields
+        let result = sqlx::query_as::<_, Agent>(
+            r#"
+            UPDATE agents
+            SET name = COALESCE($2, name),
+                description = COALESCE($3, description),
+                instructions = COALESCE($4, instructions),
+                model = COALESCE($5, model),
+                tools = COALESCE($6, tools),
+                routes = COALESCE($7, routes),
+                guardrails = COALESCE($8, guardrails),
+                knowledge_bases = COALESCE($9, knowledge_bases),
+                active = COALESCE($10, active)
+            WHERE id = $1
+            RETURNING id, name, description, instructions, model,
+                      tools, routes, guardrails, knowledge_bases,
+                      active, created_at, updated_at
+            "#
+        )
+        .bind(id)
+        .bind(req.name)
+        .bind(req.description)
+        .bind(req.instructions)
+        .bind(req.model)
+        .bind(req.tools)
+        .bind(req.routes)
+        .bind(req.guardrails)
+        .bind(req.knowledge_bases)
+        .bind(req.active)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(result)
+    }
+
+    pub async fn delete(pool: &sqlx::PgPool, id: Uuid) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE agents
+            SET active = false
+            WHERE id = $1 AND active = true
+            "#
+        )
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,10 @@
 use thiserror::Error;
 use sqlx::{Pool, Postgres};
 
+pub mod agent;
+
+pub use agent::{Agent, CreateAgentRequest, UpdateAgentRequest};
+
 // Database errors
 #[derive(Error, Debug)]
 pub enum DatabaseError {

--- a/src/rest/handlers/agents.rs
+++ b/src/rest/handlers/agents.rs
@@ -1,0 +1,132 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::Serialize;
+use std::sync::Arc;
+use uuid::Uuid;
+use utoipa::ToSchema;
+
+use crate::models::{Agent, AppState, CreateAgentRequest, UpdateAgentRequest};
+use crate::rest::error::{ApiError, ApiResult};
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgentResponse {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub instructions: String,
+    pub model: String,
+    pub tools: serde_json::Value,
+    pub routes: serde_json::Value,
+    pub guardrails: serde_json::Value,
+    pub knowledge_bases: serde_json::Value,
+    pub active: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<Agent> for AgentResponse {
+    fn from(agent: Agent) -> Self {
+        Self {
+            id: agent.id.to_string(),
+            name: agent.name,
+            description: agent.description,
+            instructions: agent.instructions,
+            model: agent.model,
+            tools: agent.tools,
+            routes: agent.routes,
+            guardrails: agent.guardrails,
+            knowledge_bases: agent.knowledge_bases,
+            active: agent.active,
+            created_at: agent.created_at.to_rfc3339(),
+            updated_at: agent.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+pub async fn list_agents(
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<Vec<AgentResponse>>> {
+    let agents = Agent::find_all(&state.db)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to list agents: {}", e)))?;
+    
+    let response: Vec<AgentResponse> = agents.into_iter().map(Into::into).collect();
+    Ok(Json(response))
+}
+
+pub async fn get_agent(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> ApiResult<Json<AgentResponse>> {
+    // Try parsing as UUID first, then as name
+    let agent = if let Ok(uuid) = Uuid::parse_str(&id) {
+        Agent::find_by_id(&state.db, uuid).await
+    } else {
+        Agent::find_by_name(&state.db, &id).await
+    }
+    .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to fetch agent: {}", e)))?
+    .ok_or(ApiError::NotFound("Agent not found".to_string()))?;
+
+    Ok(Json(agent.into()))
+}
+
+pub async fn create_agent(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateAgentRequest>,
+) -> ApiResult<Json<AgentResponse>> {
+    // Check if agent with same name already exists
+    if let Ok(Some(_)) = Agent::find_by_name(&state.db, &req.name).await {
+        return Err(ApiError::Conflict(format!("Agent '{}' already exists", req.name)));
+    }
+
+    let agent = Agent::create(&state.db, req)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to create agent: {}", e)))?;
+
+    Ok(Json(agent.into()))
+}
+
+pub async fn update_agent(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<UpdateAgentRequest>,
+) -> ApiResult<Json<AgentResponse>> {
+    let uuid = Uuid::parse_str(&id)
+        .map_err(|_| ApiError::BadRequest("Invalid agent ID format".to_string()))?;
+
+    // If updating name, check if new name already exists
+    if let Some(ref new_name) = req.name {
+        if let Ok(Some(existing)) = Agent::find_by_name(&state.db, new_name).await {
+            if existing.id != uuid {
+                return Err(ApiError::Conflict(format!("Agent '{}' already exists", new_name)));
+            }
+        }
+    }
+
+    let agent = Agent::update(&state.db, uuid, req)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to update agent: {}", e)))?
+        .ok_or(ApiError::NotFound("Agent not found".to_string()))?;
+
+    Ok(Json(agent.into()))
+}
+
+pub async fn delete_agent(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> ApiResult<()> {
+    let uuid = Uuid::parse_str(&id)
+        .map_err(|_| ApiError::BadRequest("Invalid agent ID format".to_string()))?;
+
+    let deleted = Agent::delete(&state.db, uuid)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("Failed to delete agent: {}", e)))?;
+
+    if !deleted {
+        return Err(ApiError::NotFound("Agent not found".to_string()));
+    }
+
+    Ok(())
+}

--- a/src/rest/handlers/mod.rs
+++ b/src/rest/handlers/mod.rs
@@ -1,3 +1,4 @@
 pub mod service_accounts;
 pub mod roles;
 pub mod role_bindings;
+pub mod agents;

--- a/src/rest/openapi.rs
+++ b/src/rest/openapi.rs
@@ -9,9 +9,11 @@ use crate::rest::{
         service_accounts::{CreateServiceAccountRequest, ServiceAccountResponse},
         roles::{CreateRoleRequest, RoleResponse, RuleRequest, RuleResponse},
         role_bindings::{CreateRoleBindingRequest, RoleBindingResponse, RoleRefRequest, SubjectRequest},
+        agents::AgentResponse,
     },
     error::ErrorResponse,
 };
+use crate::models::{CreateAgentRequest, UpdateAgentRequest};
 use crate::rbac::SubjectType;
 
 #[derive(OpenApi)]
@@ -34,6 +36,11 @@ use crate::rbac::SubjectType;
         crate::rest::openapi::get_role_binding,
         crate::rest::openapi::create_role_binding,
         crate::rest::openapi::delete_role_binding,
+        crate::rest::openapi::list_agents,
+        crate::rest::openapi::get_agent,
+        crate::rest::openapi::create_agent,
+        crate::rest::openapi::update_agent,
+        crate::rest::openapi::delete_agent,
     ),
     components(
         schemas(
@@ -53,6 +60,9 @@ use crate::rbac::SubjectType;
             SubjectType,
             ErrorResponse,
             crate::rest::error::ErrorDetails,
+            AgentResponse,
+            CreateAgentRequest,
+            UpdateAgentRequest,
         )
     ),
     modifiers(&SecurityAddon),
@@ -62,6 +72,7 @@ use crate::rbac::SubjectType;
         (name = "Service Accounts", description = "Service account management"),
         (name = "Roles", description = "Role management"),
         (name = "Role Bindings", description = "Role binding management"),
+        (name = "Agents", description = "Agent management"),
     ),
     info(
         title = "Raworc REST API",
@@ -384,3 +395,102 @@ pub async fn create_role_binding() {}
 )]
 #[allow(dead_code)]
 pub async fn delete_role_binding() {}
+
+// Agent endpoints
+#[utoipa::path(
+    get,
+    path = "/api/v1/agents",
+    tag = "Agents",
+    security(
+        ("bearer_auth" = [])
+    ),
+    responses(
+        (status = 200, description = "List of agents", body = Vec<AgentResponse>),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
+    ),
+)]
+#[allow(dead_code)]
+pub async fn list_agents() {}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/agents/{id}",
+    tag = "Agents",
+    security(
+        ("bearer_auth" = [])
+    ),
+    params(
+        ("id" = String, Path, description = "Agent ID or name"),
+    ),
+    responses(
+        (status = 200, description = "Agent details", body = AgentResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+    ),
+)]
+#[allow(dead_code)]
+pub async fn get_agent() {}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/agents",
+    tag = "Agents",
+    request_body = CreateAgentRequest,
+    security(
+        ("bearer_auth" = [])
+    ),
+    responses(
+        (status = 200, description = "Agent created", body = AgentResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
+        (status = 409, description = "Agent already exists", body = ErrorResponse),
+    ),
+)]
+#[allow(dead_code)]
+pub async fn create_agent() {}
+
+#[utoipa::path(
+    put,
+    path = "/api/v1/agents/{id}",
+    tag = "Agents",
+    request_body = UpdateAgentRequest,
+    security(
+        ("bearer_auth" = [])
+    ),
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+    ),
+    responses(
+        (status = 200, description = "Agent updated", body = AgentResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+        (status = 409, description = "Agent name conflict", body = ErrorResponse),
+    ),
+)]
+#[allow(dead_code)]
+pub async fn update_agent() {}
+
+#[utoipa::path(
+    delete,
+    path = "/api/v1/agents/{id}",
+    tag = "Agents",
+    security(
+        ("bearer_auth" = [])
+    ),
+    params(
+        ("id" = String, Path, description = "Agent ID"),
+    ),
+    responses(
+        (status = 204, description = "Agent deleted"),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ErrorResponse),
+        (status = 404, description = "Agent not found", body = ErrorResponse),
+    ),
+)]
+#[allow(dead_code)]
+pub async fn delete_agent() {}

--- a/src/rest/routes.rs
+++ b/src/rest/routes.rs
@@ -1,7 +1,7 @@
 use axum::{
     http::StatusCode,
     middleware,
-    routing::{delete, get, post},
+    routing::{delete, get, post, put},
     Router,
 };
 use std::sync::Arc;
@@ -38,6 +38,12 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/role-bindings", post(handlers::role_bindings::create_role_binding))
         .route("/role-bindings/{id}", get(handlers::role_bindings::get_role_binding))
         .route("/role-bindings/{id}", delete(handlers::role_bindings::delete_role_binding))
+        // Agent endpoints
+        .route("/agents", get(handlers::agents::list_agents))
+        .route("/agents", post(handlers::agents::create_agent))
+        .route("/agents/{id}", get(handlers::agents::get_agent))
+        .route("/agents/{id}", put(handlers::agents::update_agent))
+        .route("/agents/{id}", delete(handlers::agents::delete_agent))
         .layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
 
     let api_routes = public_routes.merge(protected_routes).with_state(state.clone());


### PR DESCRIPTION
## Summary
This PR implements basic agent management functionality with CRUD operations for agents.

## Features
- **Database Schema**: New `agents` table with comprehensive fields
- **Agent Model**: Full CRUD operations with runtime SQL queries
- **REST API**: Complete set of endpoints for agent management
- **OpenAPI/Swagger**: Full documentation for all agent endpoints
- **Flexible Lookup**: Support for lookup by both UUID and name
- **Soft Delete**: Agents are marked inactive rather than deleted
- **JSON Fields**: Support for tools, routes, guardrails, and knowledge_bases as JSONB

## Agent Fields
- `name` - Unique agent identifier
- `description` - Optional description
- `instructions` - Agent system instructions
- `model` - AI model to use (e.g., gpt-4)
- `tools` - JSON array of available tools
- `routes` - JSON array of routing rules
- `guardrails` - JSON array of safety constraints
- `knowledge_bases` - JSON array of knowledge sources

## API Endpoints
- `GET /api/v1/agents` - List all active agents
- `POST /api/v1/agents` - Create new agent
- `GET /api/v1/agents/{id}` - Get agent by ID or name
- `PUT /api/v1/agents/{id}` - Update agent
- `DELETE /api/v1/agents/{id}` - Soft delete agent

## Testing
A comprehensive testing plan is included in `docs/agent-testing-plan.md`

## Migration
Run the new migration:
```bash
psql $DATABASE_URL < migrations/002_create_agents_table.sql
```