### PR TITLE
refactor: change API version from v1 to v0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,7 +84,7 @@ raworc> /help             # Show available commands
 ## 📝 Version Information
 
 - **Current Version**: 0.1.0
-- **API Version**: v1
+- **API Version**: v0
 - **Last Updated**: January 2025
 
 ---

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -4,7 +4,7 @@
 
 Raworc provides a comprehensive REST API for managing platform operations, authentication, and role-based access control.
 
-- **Base URL**: `/api/v1`
+- **Base URL**: `/api/v0`
 - **Authentication**: Bearer token (JWT)
 - **Content-Type**: `application/json`
 
@@ -39,7 +39,7 @@ Get API version information.
 ```json
 {
   "version": "0.1.0",
-  "api": "v1"
+  "api": "v0"
 }
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,7 +348,7 @@ async fn validate_token(server_url: &str, token: &str) -> Result<Option<String>>
     let client = reqwest::Client::new();
 
     match client
-        .get(format!("{server_url}/api/v1/auth/me"))
+        .get(format!("{server_url}/api/v0/auth/me"))
         .header("Authorization", format!("Bearer {token}"))
         .send()
         .await
@@ -420,7 +420,7 @@ async fn auth_login() -> Result<()> {
     });
 
     let response = client
-        .post(format!("{server_url}/api/v1/auth/internal"))
+        .post(format!("{server_url}/api/v0/auth/internal"))
         .header("Content-Type", "application/json")
         .json(&login_request)
         .send()
@@ -484,7 +484,7 @@ async fn get_auth_status() -> Result<String> {
             // Check server reachability using REST endpoint
             let client = reqwest::Client::new();
             let server_reachable = match client
-                .get(format!("{}/api/v1/version", config.server))
+                .get(format!("{}/api/v0/version", config.server))
                 .send()
                 .await
             {
@@ -625,9 +625,9 @@ fn show_connect_help() {
     println!("  /quit, /q, q, quit, exit         - Exit interactive mode");
     println!();
     println!(" Examples:");
-    println!("  /api version                     - GET /api/v1/version");
-    println!("  /api service-accounts            - GET /api/v1/service-accounts");
-    println!("  /api GET roles                   - GET /api/v1/roles");
+    println!("  /api version                     - GET /api/v0/version");
+    println!("  /api service-accounts            - GET /api/v0/service-accounts");
+    println!("  /api GET roles                   - GET /api/v0/roles");
     println!("  /api POST roles {{\"name\":\"test\",\"rules\":[]}}");
     println!("  /api DELETE roles/test-role");
     println!("  /api PUT service-accounts/admin {{\"description\":\"Updated\"}}");
@@ -681,7 +681,7 @@ async fn execute_api_request(server_url: &str, input: &str) -> Result<()> {
     };
 
     let client = reqwest::Client::new();
-    let url = format!("{server_url}/api/v1/{endpoint}");
+    let url = format!("{server_url}/api/v0/{endpoint}");
     
     let mut request = match method.as_str() {
         "GET" => client.get(&url),

--- a/src/rest/middleware.rs
+++ b/src/rest/middleware.rs
@@ -28,9 +28,9 @@ pub async fn auth_middleware(
 ) -> Result<Response, StatusCode> {
     // Skip auth for public endpoints
     let path = request.uri().path();
-    if path == "/api/v1/health" || 
-       path == "/api/v1/version" || 
-       path.starts_with("/api/v1/auth/") ||
+    if path == "/api/v0/health" || 
+       path == "/api/v0/version" || 
+       path.starts_with("/api/v0/auth/") ||
        path.starts_with("/swagger-ui") ||
        path == "/api-docs/openapi.json" {
         return Ok(next.run(request).await);

--- a/src/rest/openapi.rs
+++ b/src/rest/openapi.rs
@@ -102,7 +102,7 @@ impl Modify for SecurityAddon {
 // Health endpoints
 #[utoipa::path(
     get,
-    path = "/api/v1/health",
+    path = "/api/v0/health",
     tag = "Health",
     responses(
         (status = 200, description = "Service is healthy"),
@@ -113,7 +113,7 @@ pub async fn health() {}
 
 #[utoipa::path(
     get,
-    path = "/api/v1/version",
+    path = "/api/v0/version",
     tag = "Health",
     responses(
         (status = 200, description = "API version", body = String),
@@ -125,7 +125,7 @@ pub async fn version() {}
 // Auth endpoints
 #[utoipa::path(
     post,
-    path = "/api/v1/auth/internal",
+    path = "/api/v0/auth/internal",
     tag = "Auth",
     request_body = LoginRequest,
     responses(
@@ -138,7 +138,7 @@ pub async fn login() {}
 
 #[utoipa::path(
     post,
-    path = "/api/v1/auth/external",
+    path = "/api/v0/auth/external",
     tag = "Auth",
     request_body = ExternalLoginRequest,
     security(
@@ -155,7 +155,7 @@ pub async fn external_login() {}
 
 #[utoipa::path(
     get,
-    path = "/api/v1/auth/me",
+    path = "/api/v0/auth/me",
     tag = "Auth",
     security(
         ("bearer_auth" = [])
@@ -171,7 +171,7 @@ pub async fn me() {}
 // Service Account endpoints
 #[utoipa::path(
     get,
-    path = "/api/v1/service-accounts",
+    path = "/api/v0/service-accounts",
     tag = "Service Accounts",
     security(
         ("bearer_auth" = [])
@@ -187,7 +187,7 @@ pub async fn list_service_accounts() {}
 
 #[utoipa::path(
     get,
-    path = "/api/v1/service-accounts/{id}",
+    path = "/api/v0/service-accounts/{id}",
     tag = "Service Accounts",
     security(
         ("bearer_auth" = [])
@@ -207,7 +207,7 @@ pub async fn get_service_account() {}
 
 #[utoipa::path(
     post,
-    path = "/api/v1/service-accounts",
+    path = "/api/v0/service-accounts",
     tag = "Service Accounts",
     request_body = CreateServiceAccountRequest,
     security(
@@ -226,7 +226,7 @@ pub async fn create_service_account() {}
 
 #[utoipa::path(
     delete,
-    path = "/api/v1/service-accounts/{id}",
+    path = "/api/v0/service-accounts/{id}",
     tag = "Service Accounts",
     security(
         ("bearer_auth" = [])
@@ -247,7 +247,7 @@ pub async fn delete_service_account() {}
 // Role endpoints
 #[utoipa::path(
     get,
-    path = "/api/v1/roles",
+    path = "/api/v0/roles",
     tag = "Roles",
     security(
         ("bearer_auth" = [])
@@ -263,7 +263,7 @@ pub async fn list_roles() {}
 
 #[utoipa::path(
     get,
-    path = "/api/v1/roles/{id}",
+    path = "/api/v0/roles/{id}",
     tag = "Roles",
     security(
         ("bearer_auth" = [])
@@ -283,7 +283,7 @@ pub async fn get_role() {}
 
 #[utoipa::path(
     post,
-    path = "/api/v1/roles",
+    path = "/api/v0/roles",
     tag = "Roles",
     request_body = CreateRoleRequest,
     security(
@@ -302,7 +302,7 @@ pub async fn create_role() {}
 
 #[utoipa::path(
     delete,
-    path = "/api/v1/roles/{id}",
+    path = "/api/v0/roles/{id}",
     tag = "Roles",
     security(
         ("bearer_auth" = [])
@@ -323,7 +323,7 @@ pub async fn delete_role() {}
 // Role Binding endpoints
 #[utoipa::path(
     get,
-    path = "/api/v1/role-bindings",
+    path = "/api/v0/role-bindings",
     tag = "Role Bindings",
     security(
         ("bearer_auth" = [])
@@ -339,7 +339,7 @@ pub async fn list_role_bindings() {}
 
 #[utoipa::path(
     get,
-    path = "/api/v1/role-bindings/{id}",
+    path = "/api/v0/role-bindings/{id}",
     tag = "Role Bindings",
     security(
         ("bearer_auth" = [])
@@ -359,7 +359,7 @@ pub async fn get_role_binding() {}
 
 #[utoipa::path(
     post,
-    path = "/api/v1/role-bindings",
+    path = "/api/v0/role-bindings",
     tag = "Role Bindings",
     request_body = CreateRoleBindingRequest,
     security(
@@ -378,7 +378,7 @@ pub async fn create_role_binding() {}
 
 #[utoipa::path(
     delete,
-    path = "/api/v1/role-bindings/{id}",
+    path = "/api/v0/role-bindings/{id}",
     tag = "Role Bindings",
     security(
         ("bearer_auth" = [])
@@ -399,7 +399,7 @@ pub async fn delete_role_binding() {}
 // Agent endpoints
 #[utoipa::path(
     get,
-    path = "/api/v1/agents",
+    path = "/api/v0/agents",
     tag = "Agents",
     security(
         ("bearer_auth" = [])
@@ -415,7 +415,7 @@ pub async fn list_agents() {}
 
 #[utoipa::path(
     get,
-    path = "/api/v1/agents/{id}",
+    path = "/api/v0/agents/{id}",
     tag = "Agents",
     security(
         ("bearer_auth" = [])
@@ -435,7 +435,7 @@ pub async fn get_agent() {}
 
 #[utoipa::path(
     post,
-    path = "/api/v1/agents",
+    path = "/api/v0/agents",
     tag = "Agents",
     request_body = CreateAgentRequest,
     security(
@@ -454,7 +454,7 @@ pub async fn create_agent() {}
 
 #[utoipa::path(
     put,
-    path = "/api/v1/agents/{id}",
+    path = "/api/v0/agents/{id}",
     tag = "Agents",
     request_body = UpdateAgentRequest,
     security(
@@ -477,7 +477,7 @@ pub async fn update_agent() {}
 
 #[utoipa::path(
     delete,
-    path = "/api/v1/agents/{id}",
+    path = "/api/v0/agents/{id}",
     tag = "Agents",
     security(
         ("bearer_auth" = [])

--- a/src/rest/routes.rs
+++ b/src/rest/routes.rs
@@ -49,7 +49,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let api_routes = public_routes.merge(protected_routes).with_state(state.clone());
 
     Router::new()
-        .nest("/api/v1", api_routes)
+        .nest("/api/v0", api_routes)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         .layer(middleware::from_fn(request_logging_middleware))
         .layer(TraceLayer::new_for_http())
@@ -62,6 +62,6 @@ async fn health() -> StatusCode {
 async fn version() -> axum::Json<serde_json::Value> {
     axum::Json(serde_json::json!({
         "version": "0.1.0",
-        "api": "v1"
+        "api": "v0"
     }))
 }

--- a/src/rest/server.rs
+++ b/src/rest/server.rs
@@ -82,7 +82,7 @@ PID: {}
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
 
     info!("Server started successfully!");
-    info!("REST API Endpoint: http://{}:{}/api/v1", host, port);
+    info!("REST API Endpoint: http://{}:{}/api/v0", host, port);
     info!("Swagger UI: http://{}:{}/swagger-ui/", host, port);
     info!("OpenAPI JSON: http://{}:{}/api-docs/openapi.json", host, port);
     info!("Ready to accept requests...");


### PR DESCRIPTION
## Summary
This PR changes the API version from v1 to v0 across the entire codebase.

## Changes
- **API Routes**: All endpoints now use `/api/v0` instead of `/api/v1`
- **Documentation**: Updated all API references in documentation
- **CLI**: Updated authentication and API calls to use v0
- **OpenAPI**: Updated all path definitions to v0
- **Server Messages**: Updated startup messages to show v0
- **Middleware**: Updated auth middleware path checks

## Testing
✓ Tested all endpoints work with v0
✓ Verified authentication works
✓ Confirmed old v1 endpoints return 404
✓ Checked Swagger UI still functions

## Note
Kubernetes `apiVersion: v1` references were intentionally left unchanged as they refer to Kubernetes API versions, not our REST API.