### PR TITLE
fix: use description column instead of email in service_accounts

### DIFF
--- a/migrations/20240101120000_create_rbac_tables.sql
+++ b/migrations/20240101120000_create_rbac_tables.sql
@@ -6,7 +6,7 @@ CREATE TABLE service_accounts (
     id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
     namespace TEXT NOT NULL,
-    email TEXT UNIQUE,
+    description TEXT,
     password_hash TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW()
@@ -56,7 +56,7 @@ CREATE TRIGGER update_role_bindings_updated_at BEFORE UPDATE ON role_bindings
 
 -- Create indexes for performance
 CREATE INDEX idx_service_accounts_namespace ON service_accounts(namespace);
-CREATE INDEX idx_service_accounts_email ON service_accounts(email);
+CREATE INDEX idx_service_accounts_description ON service_accounts(description);
 CREATE INDEX idx_roles_namespace ON roles(namespace);
 CREATE INDEX idx_role_bindings_namespace ON role_bindings(namespace);
 CREATE INDEX idx_role_bindings_subjects ON role_bindings USING GIN (subjects);

--- a/migrations/20240104120000_update_service_accounts_fields.sql
+++ b/migrations/20240104120000_update_service_accounts_fields.sql
@@ -1,7 +1,4 @@
--- Update service_accounts table to match the struct fields
-
--- Rename email column to description since that's what it's being used for
-ALTER TABLE service_accounts RENAME COLUMN email TO description;
+-- Update service_accounts table to add new fields
 
 -- Add active column with default true
 ALTER TABLE service_accounts ADD COLUMN active BOOLEAN DEFAULT true;


### PR DESCRIPTION
## Summary
Fixes the seeding error where the code expects `description` column but migrations created `email` column.

## Changes
- Update initial migration to create `description` column instead of `email`
- Update index name from `idx_service_accounts_email` to `idx_service_accounts_description`
- Simplify migration 004 to just add the new fields (active and last_login_at)

## Notes
This fix requires dropping and recreating the database since we're changing the initial migration.