### PR TITLE
docs: add CLI connection instructions to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ cargo build --release
 
 # In another terminal, authenticate
 ./target/release/raworc auth
+
+# Connect to the CLI (default endpoint: http://localhost:8080)
+./target/release/raworc --endpoint http://localhost:8080
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary
- Added CLI connection instructions to README quick start section
- Shows how to connect to the CLI with endpoint specification

## Test plan
- [x] Verify README renders correctly
- [x] Instructions are clear and concise