### PR TITLE
fix: correct CLI connection command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ cargo build --release
 # In another terminal, authenticate
 ./target/release/raworc auth
 
-# Connect to the CLI (default endpoint: http://localhost:8080)
-./target/release/raworc --endpoint http://localhost:8080
+# Connect to the server
+./target/release/raworc connect
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary
- Fixed incorrect CLI connection command in README
- Changed from non-existent `--endpoint` flag to proper `connect` command

## Changes
- Replaced `./target/release/raworc --endpoint http://localhost:8080` with `./target/release/raworc connect`

## Test plan
- [x] Verified command matches actual CLI usage in documentation
- [x] Checked quickstart guide shows correct `raworc connect` command